### PR TITLE
修复getSystemInfo返回数据中platform的type

### DIFF
--- a/types/api/device/system.d.ts
+++ b/types/api/device/system.d.ts
@@ -40,10 +40,10 @@ declare namespace my {
 
     /**
      * 系统名：Android，iOS
-     * * 注意: 小程序文档中写的Android/iOS, 实际调用返回值为 android/ios/iphone(低版本)
-     *      未避免小程序框架后续改造造成不兼容，建议转换成小写之后再进行比较
+     * * 注意: 小程序文档中写的Android/iOS,低版本返回值为 android/ios/iphone
+     *        建议转换成小写之后再进行比较
      */
-    readonly platform: 'android' | 'ios' | 'iphone';
+    readonly platform: 'Android' | 'iOS' | 'iPhone' | 'iPhone OS';
 
     /**
      * 屏幕高度


### PR DESCRIPTION
fix: my.getSystemInfo的platform按官网定义
最近版本的小程序该API返回值已是文档定义的值，没必要在留着低版本的值
既然备注里都写了建议转换成小写字母