### PR TITLE
把全局变量申明放入单独的文件里

### DIFF
--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -96,15 +96,3 @@ declare namespace tinyapp {
       }
     & ThisType<IAppInstance<G>>;
 }
-
-/**
- * `App()` 接受一个 object 作为参数，用来配置小程序的生命周期等。
- */
-/* tslint:disable:no-unnecessary-generics */
-declare function App<G>(options: tinyapp.AppOptions<G>): void;
-/* tslint:enable:no-unnecessary-generics */
-
-/**
- * 获取小程序实例，一般用在各个子页面之中获取顶层应用。
- */
-declare function getApp(): { globalData: any };

--- a/types/component.d.ts
+++ b/types/component.d.ts
@@ -97,13 +97,3 @@ declare namespace tinyapp {
     }
     & ThisType<IComponentInstance<P, D> & M>;
 }
-
-/* tslint:disable:no-unnecessary-generics */
-declare function Component<P, D, M extends tinyapp.IComponentMethods>(
-  options: tinyapp.ComponentOptions<
-    P,
-    D,
-    M
-  >
-): void;
-/* tslint:enable:no-unnecessary-generics */

--- a/types/event.d.ts
+++ b/types/event.d.ts
@@ -1,0 +1,49 @@
+declare namespace tinyapp {
+  /**
+   * 事件对象 https://docs.alipay.com/mini/framework/events#a-namefc3wdba%E4%BA%8B%E4%BB%B6%E5%AF%B9%E8%B1%A1
+   */
+  interface IBaseEvent {
+    readonly type: string;
+    readonly timeStamp: number;
+    readonly target: {
+      readonly tagName: string;
+      readonly dataset: Readonly<Record<string, any>>;
+      readonly targetDataset: Readonly<Record<string, any>>;
+      readonly offsetLeft: number;
+      readonly offsetTop: number;
+    };
+    readonly currentTarget: {
+      readonly tagName: string;
+      readonly dataset: Readonly<Record<string, any>>;
+      readonly offsetLeft: number;
+      readonly offsetTop: number;
+    };
+  }
+
+  interface ICustomEvent extends IBaseEvent {
+    /**
+     * 自定义事件所携带的数据，如表单组件的提交事件会携带用户的输入信息，
+     * 媒体的错误事件会携带错误信息，详细的描述请参考组件定义中各个事件的定义。
+     */
+    readonly detail: Readonly<Record<string, any>>;
+  }
+
+  interface ITouch {
+    readonly identifier: number;
+    readonly pageX: number;
+    readonly pageY: number;
+    readonly clientX: number;
+    readonly clientY: number;
+  }
+
+  interface ICanvasTouch {
+    readonly identifier: number;
+    readonly x: number;
+    readonly y: number;
+  }
+
+  interface ITouchEvent extends IBaseEvent {
+    readonly touches: ReadonlyArray<ITouch | ICanvasTouch>;
+    readonly changedTouches: ReadonlyArray<ITouch | ICanvasTouch>;
+  }
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,35 @@
+/**
+ * `App()` 接受一个 object 作为参数，用来配置小程序的生命周期等。
+ */
+/* tslint:disable:no-unnecessary-generics */
+declare function App<G>(options: tinyapp.AppOptions<G>): void;
+/* tslint:enable:no-unnecessary-generics */
+
+/**
+ * 获取小程序实例，一般用在各个子页面之中获取顶层应用。
+ */
+declare function getApp(): { globalData: any };
+
+/**
+ * Page() 函数用来注册一个页面。
+ * 接受一个 object 参数，其指定页面的初始数据、生命周期函数、事件处理函数等。
+ */
+/* tslint:disable:no-unnecessary-generics */
+declare function Page<D>(options: tinyapp.PageOptions<D>): void;
+/* tslint:enable:no-unnecessary-generics */
+
+/**
+ * getCurrentPages() 函数用于获取当前页面栈的实例，
+ * 以数组形式按栈的顺序给出，第一个元素为首页，最后一个元素为当前页面。
+ */
+declare function getCurrentPages(): Array<tinyapp.IPageInstance<any>>;
+
+/* tslint:disable:no-unnecessary-generics */
+declare function Component<P, D, M extends tinyapp.IComponentMethods>(
+  options: tinyapp.ComponentOptions<
+    P,
+    D,
+    M
+  >
+): void;
+/* tslint:enable:no-unnecessary-generics */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,53 +4,5 @@
 /// <reference path="./component.d.ts" />
 /// <reference path="./page.d.ts" />
 /// <reference path="./api/index.d.ts" />
-
-declare namespace tinyapp {
-  /**
-   * 事件对象 https://docs.alipay.com/mini/framework/events#a-namefc3wdba%E4%BA%8B%E4%BB%B6%E5%AF%B9%E8%B1%A1
-   */
-  interface IBaseEvent {
-    readonly type: string;
-    readonly timeStamp: number;
-    readonly target: {
-      readonly tagName: string;
-      readonly dataset: Readonly<Record<string, any>>;
-      readonly targetDataset: Readonly<Record<string, any>>;
-      readonly offsetLeft: number;
-      readonly offsetTop: number;
-    };
-    readonly currentTarget: {
-      readonly tagName: string;
-      readonly dataset: Readonly<Record<string, any>>;
-      readonly offsetLeft: number;
-      readonly offsetTop: number;
-    };
-  }
-
-  interface ICustomEvent extends IBaseEvent {
-    /**
-     * 自定义事件所携带的数据，如表单组件的提交事件会携带用户的输入信息，
-     * 媒体的错误事件会携带错误信息，详细的描述请参考组件定义中各个事件的定义。
-     */
-    readonly detail: Readonly<Record<string, any>>;
-  }
-
-  interface ITouch {
-    readonly identifier: number;
-    readonly pageX: number;
-    readonly pageY: number;
-    readonly clientX: number;
-    readonly clientY: number;
-  }
-
-  interface ICanvasTouch {
-    readonly identifier: number;
-    readonly x: number;
-    readonly y: number;
-  }
-
-  interface ITouchEvent extends IBaseEvent {
-    readonly touches: ReadonlyArray<ITouch | ICanvasTouch>;
-    readonly changedTouches: ReadonlyArray<ITouch | ICanvasTouch>;
-  }
-}
+/// <reference path="./global.d.ts" />
+/// <reference path="./event.d.ts" />

--- a/types/page.d.ts
+++ b/types/page.d.ts
@@ -155,17 +155,3 @@ declare namespace tinyapp {
       }
     & ThisType<IPageInstance<D>>;
 }
-
-/**
- * Page() 函数用来注册一个页面。
- * 接受一个 object 参数，其指定页面的初始数据、生命周期函数、事件处理函数等。
- */
-/* tslint:disable:no-unnecessary-generics */
-declare function Page<D>(options: tinyapp.PageOptions<D>): void;
-/* tslint:enable:no-unnecessary-generics */
-
-/**
- * getCurrentPages() 函数用于获取当前页面栈的实例，
- * 以数组形式按栈的顺序给出，第一个元素为首页，最后一个元素为当前页面。
- */
-declare function getCurrentPages(): Array<tinyapp.IPageInstance<any>>;


### PR DESCRIPTION
在 Remax 里我们[只需要 API 的类型](https://github.com/remaxjs/remax/pull/608)，现在 `App` 这样的全局变量跟其他类型写在一起会有污染。这个 PR 把 `App` 这样的全局变量独立写到 `framework.d.ts` 文件里。