### PR TITLE
fix: 修复一些类型定义错误和回调方法

### DIFF
--- a/types/api/cache.d.ts
+++ b/types/api/cache.d.ts
@@ -152,11 +152,28 @@ declare namespace my {
   function removeStorageSync(options: IRemoveStorageSyncOptions): void;
 
   /**
+   * 清除本地数据缓存异步方法 参数
+   */
+  interface IClearStorageOptions {
+    /**
+     * 调用成功的回调函数
+     */
+    success?: () => void;
+    /**
+     * 调用失败的回调函数
+     */
+    fail?: () => void;
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?: () => void;
+  }
+  /**
    * 清除本地数据缓存。
    *
    * > 清空内嵌内嵌webview的存储时不会同时清空当前小程序本身的存储数据
    */
-  function clearStorage(): void;
+  function clearStorage(options?: IClearStorageOptions): void;
 
   /**
    * 同步清除本地数据缓存。

--- a/types/api/device/clipboard.d.ts
+++ b/types/api/device/clipboard.d.ts
@@ -6,7 +6,28 @@ declare namespace my {
     /**
      * 调用成功的回调函数
      */
-    success?(text: string): void;
+    success?(res: { text: string }): void;
+
+    /**
+     * 调用失败的回调函数
+     */
+    fail?(): void;
+
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?(): void;
+  }
+
+  interface ISetClipboardOptions {
+    /**
+     * 剪贴板内容
+     */
+    text: string;
+    /**
+     * 调用成功的回调函数
+     */
+    success?(res: { success: boolean }): void;
 
     /**
      * 调用失败的回调函数
@@ -27,10 +48,5 @@ declare namespace my {
   /**
    * 设置剪贴板数据。
    */
-  function setClipboard(options: IClipboardOptions & {
-    /**
-     * 剪贴板数据
-     */
-    text: string;
-  }): void;
+  function setClipboard(options: ISetClipboardOptions): void;
 }

--- a/types/api/device/settings.d.ts
+++ b/types/api/device/settings.d.ts
@@ -2,7 +2,7 @@
  * @file 设置
  */
 declare namespace my {
-  type SettingScopeList = 'scope.userInfo' | 'scope.location' | 'scope.album' | 'scope.camera' | 'scope.audioRecord';
+  type SettingScopeList = 'userInfo' | 'location' | 'album' | 'camera' | 'audioRecord';
 
   interface IOpenSettingSuccessOptions {
     /**

--- a/types/api/location.d.ts
+++ b/types/api/location.d.ts
@@ -62,7 +62,10 @@ declare namespace my {
      * 国家(type>0生效)
      */
     readonly country?: string;
-    readonly bearing: string;
+    /**
+     * 官方文档中没提到,但接口有做返回,不做必有参数处理
+     */
+    readonly bearing?: string;
 
     /**
      * 纬度
@@ -112,7 +115,7 @@ declare namespace my {
     /**
      * 接口调用成功的回调函数
      */
-    success?: (res?: IGetLocationSuccessResult) => void;
+    success?: (res: IGetLocationSuccessResult) => void;
 
     /**
      * 调用失败的回调函数

--- a/types/api/media/index.d.ts
+++ b/types/api/media/index.d.ts
@@ -176,6 +176,12 @@ declare namespace my {
    */
   function saveImage(options: ISaveImageOptions): void;
 
+  /**
+   * 压缩图片的返回值
+   */
+  interface ICompressImageSuccessResult {
+    apFilePaths: string[];
+  }
   interface ICompressImageOptions {
     /**
      * 要压缩的图片地址数组
@@ -196,7 +202,7 @@ declare namespace my {
     /**
      * 调用成功的回调函数
      */
-    success?(): void;
+    success?(res: ICompressImageSuccessResult): void;
 
     /**
      * 调用失败的回调函数

--- a/types/api/open/card.d.ts
+++ b/types/api/open/card.d.ts
@@ -3,9 +3,26 @@
  */
 declare namespace my {
   /**
+   * 打开支付宝卡列表 参数
+   */
+  interface IOpenCardListOptions {
+    /**
+     * 调用成功的回调函数
+     */
+    success?: () => void;
+    /**
+     * 调用失败的回调函数
+     */
+    fail?: () => void;
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?: () => void;
+  }
+  /**
    * 打开支付宝卡列表。
    */
-  function openCardList(): void;
+  function openCardList(options?: IOpenCardListOptions): void;
 
   interface IOpenMerchantCardListOptions {
     /**

--- a/types/api/ui/feedback.d.ts
+++ b/types/api/ui/feedback.d.ts
@@ -39,10 +39,26 @@ declare namespace my {
    */
   function showToast(options: IShowToastOptions): void;
 
+  interface IHideToastOptions {
+    /**
+     * 调用成功的回调函数
+     */
+    success?(): void;
+
+    /**
+     * 调用失败的回调函数
+     */
+    fail?(): void;
+
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?(): void;
+  }
   /**
    * 隐藏消息提示框
    */
-  function hideToast(): void;
+  function hideToast(options?: IHideToastOptions): void;
 
   interface IAlertOptions {
     /**
@@ -235,6 +251,18 @@ declare namespace my {
      * 参考: https://docs.alipay.com/mini/api/ui-feedback#a-name7bgvmdamyhideloading
      */
     page?: tinyapp.IPageInstance<any>;
+    /**
+     * 调用成功的回调函数
+     */
+    success?: () => void;
+    /**
+     * 调用失败的回调函数
+     */
+    fail?: () => void;
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?: () => void;
   }
 
   /**

--- a/types/api/ui/index.d.ts
+++ b/types/api/ui/index.d.ts
@@ -14,3 +14,4 @@
 /// <reference path="./feedback.d.ts" />
 /// <reference path="./optionsSelect.d.ts" />
 /// <reference path="./font.d.ts" />
+/// <reference path="./pulldown.d.ts" />

--- a/types/api/ui/navigator.d.ts
+++ b/types/api/ui/navigator.d.ts
@@ -52,7 +52,7 @@ declare namespace my {
    */
   function navigateBack(options?: INavigateBackOptions): void;
 
-  interface IRelaunchOptions extends INavigateBaseCallbackOptions {
+  interface IReLaunchOptions extends INavigateBaseCallbackOptions {
     /**
      * 页面路径。如果页面不为 tabbar 页面则路径后可以带参数。
      * 参数规则如下：路径与参数之间使用?分隔，参数键与参数值用=相连，不同参数必须用&分隔；
@@ -64,9 +64,9 @@ declare namespace my {
    * 关闭当前所有页面，跳转到应用内的某个指定页面。
    * 基础库 1.4.0+ & 支付宝客户端 10.1.8+ 支持
    */
-  function reLaunch(options: IRelaunchOptions): void;
+  function reLaunch(options: IReLaunchOptions): void;
 
-  interface ISetNavigationBar extends INavigateBaseCallbackOptions {
+  interface ISetNavigationBarOptions extends INavigateBaseCallbackOptions {
     /**
      * 导航栏标题
      */
@@ -92,7 +92,7 @@ declare namespace my {
   /**
    * 设置导航栏文字及样式。
    */
-  function setNavigationBar(options: ISetNavigationBar): void;
+  function setNavigationBar(options: ISetNavigationBarOptions): void;
 
   /**
    * 显示导航栏 loading。
@@ -105,8 +105,27 @@ declare namespace my {
   function hideNavigationBarLoading(): void;
 
   /**
+   * 隐藏TitleBar上的返回首页图标 参数
+   */
+  interface IHideBackHomeOptions {
+    /**
+     * 调用成功的回调函数
+     */
+    success?(): void;
+
+    /**
+     * 调用失败的回调函数
+     */
+    fail?(): void;
+
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?(): void;
+  }
+  /**
    * 隐藏TitleBar上的返回首页图标，和通用菜单中的“返回首页”功能。
    * 返回首页功能出现时机：当用户启动小程序，若直接进入的页面不是小程序的首页，则会在左上角出现返回首页icon，若用户继续在页面中进入下一级页面，则在右上角更多菜单中，会出现“返回首页”功能。
    */
-  function hideBackHome(): void;
+  function hideBackHome(options?: IHideBackHomeOptions): void;
 }

--- a/types/api/ui/scroll.d.ts
+++ b/types/api/ui/scroll.d.ts
@@ -7,6 +7,20 @@ declare namespace my {
      * 滚动到页面的目标位置，单位 px
      */
     scrollTop: number;
+    /**
+     * 调用成功的回调函数
+     */
+    success?(): void;
+
+    /**
+     * 调用失败的回调函数
+     */
+    fail?(): void;
+
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?(): void;
   }
 
   /**


### PR DESCRIPTION
1. 增加方法的回调方法sucess& fail& complete
2. 修改 setClipboard的回调类型
3. 修改setNavigationBar的参数类型命名规范
4. 修改定位IGetLocationSuccessResult方法,参考官方文档,设置bearing为可选(文档中无该值)
5. 修复ui/index.d.ts未引入pulldown