### PR TITLE
fix: 修复一些类型定义错误和回调方法

### DIFF
--- a/types/api/cache.d.ts
+++ b/types/api/cache.d.ts
@@ -152,11 +152,28 @@ declare namespace my {
   function removeStorageSync(options: IRemoveStorageSyncOptions): void;
 
   /**
+   * 清除本地数据缓存异步方法 参数
+   */
+  interface IClearStorageOptions {
+    /**
+     * 调用成功的回调函数
+     */
+    success?: () => void;
+    /**
+     * 调用失败的回调函数
+     */
+    fail?: () => void;
+    /**
+     * 调用结束的回调函数（调用成功、失败都会执行）
+     */
+    complete?: () => void;
+  }
+  /**
    * 清除本地数据缓存。
    *
    * > 清空内嵌内嵌webview的存储时不会同时清空当前小程序本身的存储数据
    */
-  function clearStorage(): void;
+  function clearStorage(options?: IClearStorageOptions): void;
 
   /**
    * 同步清除本地数据缓存。

--- a/types/api/device/clipboard.d.ts
+++ b/types/api/device/clipboard.d.ts
@@ -6,7 +6,7 @@ declare namespace my {
     /**
      * 调用成功的回调函数
      */
-    success?(res: { success: string }): void;
+    success?(res: { text: string }): void;
 
     /**
      * 调用失败的回调函数
@@ -16,10 +16,13 @@ declare namespace my {
     /**
      * 调用结束的回调函数（调用成功、失败都会执行）
      */
-    complete?(res: { success: string }): void;
+    complete?(res: { text: string }): void;
   }
 
   interface ISetClipboardOptions {
+    /**
+     * 剪贴板内容
+     */
     text: string;
     /**
      * 调用失败的回调函数

--- a/types/api/location.d.ts
+++ b/types/api/location.d.ts
@@ -62,7 +62,6 @@ declare namespace my {
      * 国家(type>0生效)
      */
     readonly country?: string;
-    readonly bearing?: string;
 
     /**
      * 纬度

--- a/types/api/ui/navigator.d.ts
+++ b/types/api/ui/navigator.d.ts
@@ -66,7 +66,7 @@ declare namespace my {
    */
   function reLaunch(options: IRelaunchOptions): void;
 
-  interface ISetNavigationBar extends INavigateBaseCallbackOptions {
+  interface ISetNavigationBarOptions extends INavigateBaseCallbackOptions {
     /**
      * 导航栏标题
      */
@@ -92,7 +92,7 @@ declare namespace my {
   /**
    * 设置导航栏文字及样式。
    */
-  function setNavigationBar(options: ISetNavigationBar): void;
+  function setNavigationBar(options: ISetNavigationBarOptions): void;
 
   /**
    * 显示导航栏 loading。


### PR DESCRIPTION
1.增加clearStorage方法的回调方法sucess& fail& complete
2.修复 getClipboard的回调类型
3.修改setNavigationBar的参数类型命名规范
4.修改定位IGetLocationSuccessResult方法,参考官方文档,移除bearing为可选(文档中无该值),实际有返回