### PR TITLE
refactor: migrate getApp return value to tinyApp.IGetAppResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4
+* **Refactor**
+  - 将 `getApp` 返回的 `{ globalData: any; }` 重构成`tinyapp.IGetAppResult`;
+
 # 0.1.3
 
 * **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.4
 * **Refactor**
-  - 将 `getApp` 返回的 `{ globalData: any; }` 重构成`tinyapp.IGetAppResult`;
+  - 将 `getApp` 返回的 `{ globalData: any; }` 重构成 `tinyapp.IGetAppResult`。
 
 # 0.1.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-types",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TypeScript declarations for Alipay's mini program.",
   "scripts": {
     "lint": "dtslint types",

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -86,6 +86,21 @@ declare namespace tinyapp {
   }
 
   /**
+   * getApp()返回的小程序实例
+   *
+   * @interface IGetAppResult
+   */
+  interface IGetAppResult {
+    /**
+     * 全局状态数据
+     *
+     * @type {*}
+     * @memberof IGetAppResult
+     */
+    globalData: any;
+  }
+
+  /**
    * App 实现的接口对象
    * 参考: https://docs.alipay.com/mini/framework/app
    */

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -8,7 +8,7 @@ declare function App<G>(options: tinyapp.AppOptions<G>): void;
 /**
  * 获取小程序实例，一般用在各个子页面之中获取顶层应用。
  */
-declare function getApp(): { globalData: any };
+declare function getApp(): tinyapp.IGetAppResult;
 
 /**
  * Page() 函数用来注册一个页面。


### PR DESCRIPTION
将`getApp`目前返回的 `{ globalData: any }` 提取成`tinyApp.IGetAppResult`。